### PR TITLE
Thêm giao diện editor và manager (cơ bản để chạy )

### DIFF
--- a/db.json
+++ b/db.json
@@ -46,11 +46,22 @@
     },
     {
       "id": "adg5",
-      "title": "Sample Post",
+      "title": "a",
       "excerpt": "This is a sample post.",
-      "createdAt": "2025-07-15",
+      "createdAt": "2025-07-24",
       "slug": "sample-post",
-      "image": "https://via.placeholder.com/400x200"
+      "image": "https://via.placeholder.com/400x200",
+      "content": "123",
+      "status": "published",
+      "author": "editor"
+    },
+    {
+      "title": "Hành trình xây dựng hệ thống Blog hiện đại với vai trò Editor & Manager",
+      "content": "Trong quá trình phát triển hệ thống blog, chúng tôi đã xây dựng các chức năng hiện đại và thân thiện với người dùng, lấy cảm hứng từ các nền tảng lớn như Medium, WordPress:\n\n- Giao diện Editor với sidebar hiện đại, phân nhóm rõ ràng: Bài viết của tôi, Tất cả bài viết của tôi, Tất cả bài viết.\n- Chức năng tạo bài viết với auto-save nháp, gửi duyệt, lưu vào db.json qua API.\n- Quản lý bài viết: sửa, xóa, gửi duyệt, phân quyền rõ ràng giữa Editor và Manager.\n- Trang Manager Dashboard cho phép duyệt hoặc từ chối bài viết chờ duyệt.\n- Trang chi tiết bài viết hiển thị nội dung, bình luận, cho phép bình luận mới, hiển thị rõ tác giả bình luận.\n- Bình luận có thể xóa/sửa nếu là của mình, hiển thị thời gian gửi, phân trang.\n- Tất cả thao tác CRUD đều đồng bộ với db.json qua json-server.\n\nHệ thống này giúp quản lý nội dung hiệu quả, dễ mở rộng và nâng cấp, phù hợp cho các dự án blog cá nhân hoặc nhóm nhỏ.",
+      "status": "published",
+      "author": "editor",
+      "createdAt": "2025-07-25",
+      "id": "blogai1"
     }
   ],
   "users": [
@@ -100,6 +111,27 @@
       "author": "viewer",
       "content": "Tuyệt vời quá \n",
       "createdAt": "2025-07-13T14:07:12.893Z"
+    },
+    {
+      "id": "3980",
+      "postId": "adg5",
+      "author": "editor",
+      "content": "123",
+      "createdAt": "2025-07-25T00:24:30.480Z"
+    },
+    {
+      "id": "a88d",
+      "postId": "adg5",
+      "author": "editor",
+      "content": "345",
+      "createdAt": "2025-07-25T00:24:39.272Z"
+    },
+    {
+      "id": "dc1f",
+      "postId": "8538",
+      "author": "editor",
+      "content": "ád",
+      "createdAt": "2025-07-25T00:37:12.332Z"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "axios": "^1.10.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -928,6 +929,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "axios": "^1.10.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/layouts/EditorLayout.jsx
+++ b/src/layouts/EditorLayout.jsx
@@ -1,0 +1,76 @@
+import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
+import { PencilSquareIcon, DocumentTextIcon, BookOpenIcon } from "@heroicons/react/24/outline";
+import React from "react";
+
+const menu = [
+  {
+    to: "/editor/myposts",
+    label: "Bài viết của tôi",
+    icon: <PencilSquareIcon className="w-5 h-5 mr-2" />,
+    match: ["/editor/myposts", "/editor/posts"],
+  },
+  {
+    to: "/editor/myall",
+    label: "Tất cả bài viết của tôi",
+    icon: <DocumentTextIcon className="w-5 h-5 mr-2" />,
+    match: ["/editor/myall"],
+  },
+  {
+    to: "/editor/all",
+    label: "Tất cả bài viết",
+    icon: <BookOpenIcon className="w-5 h-5 mr-2" />,
+    match: ["/editor/all"],
+  },
+];
+
+const getCurrentUser = () => ({ username: "editor", role: "Editor" }); // Giả lập user
+
+const EditorLayout = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const user = getCurrentUser();
+
+  const handleNav = (to) => {
+    navigate(to);
+  };
+
+  const handleLogout = () => {
+    navigate("/login");
+  };
+
+  return (
+    <div className="flex min-h-screen bg-gray-50">
+      {/* Sidebar sát trái, màu khác */}
+      <aside className="w-64 bg-gray-100 p-4 border-r flex flex-col min-h-screen shadow-md fixed left-0 top-0 bottom-0 z-20">
+        <div className="text-2xl font-bold mb-8 text-blue-600 text-center tracking-wide">Editor Panel</div>
+        <nav className="flex flex-col gap-2 flex-1">
+          {menu.map((item) => {
+            const isActive = item.match.some((m) =>
+              m === location.pathname || (m.endsWith("edit") && location.pathname.startsWith(m))
+            );
+            return (
+              <button
+                key={item.to}
+                onClick={() => handleNav(item.to)}
+                className={`flex items-center w-full text-left px-4 py-2 rounded transition-colors font-medium hover:bg-blue-50 hover:text-blue-600 ${isActive ? "bg-blue-600 text-white" : "text-gray-700"}`}
+              >
+                {item.icon}
+                {item.label}
+              </button>
+            );
+          })}
+        </nav>
+        <div className="mt-auto text-center text-xs text-gray-400 pt-4 border-t">© 2025 My Blog</div>
+      </aside>
+      {/* Main content + header */}
+      <div className="flex-1 ml-64 min-h-screen flex flex-col">
+        {/* Main content */}
+        <main className="flex-1 p-8 bg-gray-50">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default EditorLayout; 

--- a/src/pages/editor/AllPostDetail.jsx
+++ b/src/pages/editor/AllPostDetail.jsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+
+const API_URL = "http://localhost:3000/posts";
+const COMMENTS_URL = "http://localhost:3000/comments";
+const getCurrentUser = () => "editor";
+
+const AllPostDetail = () => {
+  const { id } = useParams();
+  const [post, setPost] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [comments, setComments] = useState([]);
+  const [commentsLoading, setCommentsLoading] = useState(true);
+  const [commentInput, setCommentInput] = useState("");
+  const [addingComment, setAddingComment] = useState(false);
+
+  useEffect(() => {
+    fetch(`${API_URL}/${id}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setPost(data);
+        setLoading(false);
+      });
+    fetch(`${COMMENTS_URL}?postId=${id}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setComments(data);
+        setCommentsLoading(false);
+      });
+  }, [id]);
+
+  const handleAddComment = async () => {
+    if (!commentInput.trim()) return;
+    setAddingComment(true);
+    await fetch(COMMENTS_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        postId: id,
+        author: getCurrentUser(),
+        content: commentInput,
+        createdAt: new Date().toISOString(),
+      }),
+    });
+    setCommentInput("");
+    // Reload comments
+    fetch(`${COMMENTS_URL}?postId=${id}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setComments(data);
+        setCommentsLoading(false);
+        setAddingComment(false);
+      });
+  };
+
+  if (loading) return <div>Đang tải...</div>;
+  if (!post) return <div>Không tìm thấy bài viết.</div>;
+
+  return (
+    <div className="max-w-2xl mx-auto py-8">
+      <h2 className="text-2xl font-bold mb-2">{post.title}</h2>
+      <div className="text-gray-500 mb-2">Tác giả: {post.author || "-"} | Ngày tạo: {post.createdAt || "-"}</div>
+      <div className="mb-6 text-gray-800 whitespace-pre-line">{post.content}</div>
+      <div className="bg-gray-50 p-4 rounded border">
+        <h4 className="font-semibold mb-2 text-lg">Bình luận</h4>
+        {commentsLoading ? (
+          <div>Đang tải bình luận...</div>
+        ) : comments.length === 0 ? (
+          <div className="text-gray-400 text-sm">Chưa có bình luận nào.</div>
+        ) : (
+          <ul className="space-y-2 mb-2">
+            {comments.map((c) => (
+              <li key={c.id} className="text-sm border-b last:border-b-0 pb-1">
+                <span className="font-medium">
+                  {c.author === getCurrentUser() ? `${c.author} (Bạn)` : c.author}
+                </span>: {c.content}
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="flex gap-2 mt-2">
+          <input
+            className="border p-1 flex-1"
+            type="text"
+            placeholder="Viết bình luận..."
+            value={commentInput}
+            onChange={e => setCommentInput(e.target.value)}
+            onKeyDown={e => { if (e.key === "Enter") handleAddComment(); }}
+          />
+          <button
+            className="bg-blue-500 text-white px-4 rounded"
+            onClick={handleAddComment}
+            disabled={addingComment}
+          >
+            {addingComment ? "Đang gửi..." : "Gửi"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AllPostDetail; 

--- a/src/pages/editor/AllPosts.jsx
+++ b/src/pages/editor/AllPosts.jsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const API_URL = "http://localhost:3000/posts";
+
+const AllPosts = () => {
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetch(`${API_URL}?status=published`)
+      .then((res) => res.json())
+      .then((data) => {
+        setPosts(data);
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) return <div>Đang tải...</div>;
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">Tất cả bài viết đã duyệt</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {posts.map((post) => (
+          <div
+            key={post.id}
+            className="bg-white rounded shadow p-5 flex flex-col gap-2 border hover:shadow-lg transition cursor-pointer"
+            onClick={() => navigate(`/editor/all/${post.id}`)}
+          >
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-lg truncate">{post.title}</h3>
+              <span className="px-2 py-1 rounded text-xs font-medium ml-2 bg-green-100 text-green-700">Đã duyệt</span>
+            </div>
+            <div className="text-sm text-gray-500">Tác giả: {post.author || "-"}</div>
+            <div className="text-sm text-gray-500">Ngày tạo: {post.createdAt || "-"}</div>
+          </div>
+        ))}
+        {posts.length === 0 && <div className="col-span-2 text-center text-gray-400">Chưa có bài viết nào đã duyệt.</div>}
+      </div>
+    </div>
+  );
+};
+
+export default AllPosts; 

--- a/src/pages/editor/EditorPosts.jsx
+++ b/src/pages/editor/EditorPosts.jsx
@@ -1,8 +1,224 @@
-export default function EditorPosts() {
+import React, { useState } from "react";
+
+// Mock dữ liệu bài viết và bình luận
+const initialPosts = [
+  {
+    id: 1,
+    title: "Bài viết 1",
+    content: "Nội dung bài viết 1",
+    status: "Nháp",
+    comments: [
+      { id: 1, author: "editor", text: "Bình luận 1" },
+      { id: 2, author: "editor", text: "Bình luận 2" },
+    ],
+  },
+  {
+    id: 2,
+    title: "Bài viết 2",
+    content: "Nội dung bài viết 2",
+    status: "Chờ duyệt",
+    comments: [],
+  },
+];
+
+const EditorPosts = () => {
+  const [posts, setPosts] = useState(initialPosts);
+  const [showForm, setShowForm] = useState(false);
+  const [editPost, setEditPost] = useState(null);
+  const [form, setForm] = useState({ title: "", content: "" });
+  const [formMode, setFormMode] = useState("create"); // "create" hoặc "edit"
+  const [commentInputs, setCommentInputs] = useState({});
+
+  // Xử lý mở form tạo/sửa
+  const handleOpenForm = (mode, post = null) => {
+    setFormMode(mode);
+    setEditPost(post);
+    setForm(post ? { title: post.title, content: post.content } : { title: "", content: "" });
+    setShowForm(true);
+  };
+
+  // Xử lý lưu nháp hoặc gửi duyệt
+  const handleSubmit = (status) => {
+    if (formMode === "create") {
+      const newPost = {
+        id: Date.now(),
+        title: form.title,
+        content: form.content,
+        status,
+        comments: [],
+      };
+      setPosts([newPost, ...posts]);
+    } else if (formMode === "edit" && editPost) {
+      setPosts(posts.map((p) =>
+        p.id === editPost.id ? { ...p, title: form.title, content: form.content, status } : p
+      ));
+    }
+    setShowForm(false);
+    setForm({ title: "", content: "" });
+    setEditPost(null);
+  };
+
+  // Xử lý xóa bài viết
+  const handleDelete = (id) => {
+    setPosts(posts.filter((p) => p.id !== id));
+  };
+
+  // Xử lý gửi duyệt bài viết
+  const handleSubmitForReview = (id) => {
+    setPosts(posts.map((p) => (p.id === id ? { ...p, status: "Chờ duyệt" } : p)));
+  };
+
+  // Xử lý bình luận
+  const handleAddComment = (postId) => {
+    const text = commentInputs[postId]?.trim();
+    if (!text) return;
+    setPosts(posts.map((p) =>
+      p.id === postId
+        ? { ...p, comments: [...p.comments, { id: Date.now(), author: "editor", text }] }
+        : p
+    ));
+    setCommentInputs({ ...commentInputs, [postId]: "" });
+  };
+
+  // Xử lý xóa bình luận
+  const handleDeleteComment = (postId, commentId) => {
+    setPosts(posts.map((p) =>
+      p.id === postId
+        ? { ...p, comments: p.comments.filter((c) => c.id !== commentId) }
+        : p
+    ));
+  };
+
   return (
-    <div className="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
-      <h1 className="text-3xl font-bold text-blue-600 mb-6">Editor Posts</h1>
-      <p>Welcome, Editor! Create and edit posts here.</p>
+    <div className="max-w-3xl mx-auto py-8">
+      <h2 className="text-2xl font-bold mb-4">Bài viết của tôi</h2>
+      <button
+        className="mb-4 px-4 py-2 bg-blue-500 text-white rounded"
+        onClick={() => handleOpenForm("create")}
+      >
+        Tạo bài viết
+      </button>
+
+      {/* Form tạo/sửa bài viết */}
+      {showForm && (
+        <div className="border p-4 mb-6 bg-gray-50 rounded">
+          <h3 className="text-lg font-semibold mb-2">
+            {formMode === "create" ? "Tạo bài viết mới" : "Sửa bài viết"}
+          </h3>
+          <input
+            className="border p-2 w-full mb-2"
+            type="text"
+            placeholder="Tiêu đề"
+            value={form.title}
+            onChange={e => setForm({ ...form, title: e.target.value })}
+          />
+          <textarea
+            className="border p-2 w-full mb-2 min-h-[80px]"
+            placeholder="Nội dung"
+            value={form.content}
+            onChange={e => setForm({ ...form, content: e.target.value })}
+          />
+          <div className="flex gap-2">
+            <button
+              className="bg-gray-300 px-4 py-2 rounded"
+              onClick={() => handleSubmit("Nháp")}
+            >
+              Lưu nháp
+            </button>
+            <button
+              className="bg-blue-500 text-white px-4 py-2 rounded"
+              onClick={() => handleSubmit("Chờ duyệt")}
+            >
+              Gửi duyệt
+            </button>
+            <button
+              className="bg-red-400 text-white px-4 py-2 rounded ml-auto"
+              onClick={() => setShowForm(false)}
+            >
+              Hủy
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Danh sách bài viết */}
+      <div className="space-y-6">
+        {posts.map((post) => (
+          <div key={post.id} className="border rounded p-4 bg-white">
+            <div className="flex justify-between items-center mb-2">
+              <div>
+                <h4 className="font-semibold text-lg">{post.title}</h4>
+                <span className="text-sm text-gray-500">Trạng thái: {post.status}</span>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  className="text-blue-600"
+                  onClick={() => handleOpenForm("edit", post)}
+                >
+                  Sửa
+                </button>
+                <button
+                  className="text-red-600"
+                  onClick={() => handleDelete(post.id)}
+                >
+                  Xóa
+                </button>
+                {post.status === "Nháp" && (
+                  <button
+                    className="text-green-600"
+                    onClick={() => handleSubmitForReview(post.id)}
+                  >
+                    Gửi duyệt
+                  </button>
+                )}
+              </div>
+            </div>
+            <div className="mb-2 text-gray-700">{post.content}</div>
+            {/* Bình luận */}
+            {post.status === "Đã duyệt" || post.status === "Published" ? (
+              <div className="mt-2">
+                <h5 className="font-semibold mb-1">Bình luận</h5>
+                <div className="space-y-1 mb-2">
+                  {post.comments.map((c) => (
+                    <div key={c.id} className="flex items-center gap-2">
+                      <span className="text-sm">{c.text}</span>
+                      <button
+                        className="text-xs text-red-500"
+                        onClick={() => handleDeleteComment(post.id, c.id)}
+                      >
+                        Xóa
+                      </button>
+                    </div>
+                  ))}
+                </div>
+                <div className="flex gap-2">
+                  <input
+                    className="border p-1 flex-1"
+                    type="text"
+                    placeholder="Viết bình luận..."
+                    value={commentInputs[post.id] || ""}
+                    onChange={e => setCommentInputs({ ...commentInputs, [post.id]: e.target.value })}
+                    onKeyDown={e => { if (e.key === "Enter") handleAddComment(post.id); }}
+                  />
+                  <button
+                    className="bg-blue-400 text-white px-2 rounded"
+                    onClick={() => handleAddComment(post.id)}
+                  >
+                    Gửi
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="mt-2 text-gray-400 italic text-sm">
+                Bình luận chỉ mở khi bài viết đã được duyệt.
+              </div>
+            )}
+          </div>
+        ))}
+        {posts.length === 0 && <div>Chưa có bài viết nào.</div>}
+      </div>
     </div>
   );
-}
+};
+
+export default EditorPosts;

--- a/src/pages/editor/MyAllPosts.jsx
+++ b/src/pages/editor/MyAllPosts.jsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const API_URL = "http://localhost:3000/posts";
+const COMMENTS_URL = "http://localhost:3000/comments";
+const getCurrentUser = () => "editor";
+
+const MyAllPosts = () => {
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [showComments, setShowComments] = useState(null); // postId
+  const [comments, setComments] = useState([]);
+  const [commentsLoading, setCommentsLoading] = useState(false);
+  const [commentInput, setCommentInput] = useState("");
+  const [addingComment, setAddingComment] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetch(`${API_URL}?author=${getCurrentUser()}&status=published`)
+      .then((res) => res.json())
+      .then((data) => {
+        setPosts(data);
+        setLoading(false);
+      });
+  }, []);
+
+  const handleShowComments = (postId) => {
+    setCommentsLoading(true);
+    setShowComments(postId);
+    fetch(`${COMMENTS_URL}?postId=${postId}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setComments(data);
+        setCommentsLoading(false);
+      });
+  };
+
+  const handleAddComment = async (postId) => {
+    if (!commentInput.trim()) return;
+    setAddingComment(true);
+    await fetch(COMMENTS_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        postId,
+        author: getCurrentUser(),
+        content: commentInput,
+        createdAt: new Date().toISOString(),
+      }),
+    });
+    setCommentInput("");
+    handleShowComments(postId); // reload comments
+    setAddingComment(false);
+  };
+
+  if (loading) return <div>Đang tải...</div>;
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">Tất cả bài viết của tôi (đã duyệt)</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {posts.map((post) => (
+          <div
+            key={post.id}
+            className="bg-white rounded shadow p-5 flex flex-col gap-2 border hover:shadow-lg transition cursor-pointer"
+            onClick={() => navigate(`/editor/myall/${post.id}`)}
+          >
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-lg truncate">{post.title}</h3>
+              <span className="px-2 py-1 rounded text-xs font-medium ml-2 bg-green-100 text-green-700">Đã duyệt</span>
+            </div>
+            <div className="text-sm text-gray-500">Ngày tạo: {post.createdAt || "-"}</div>
+            <div className="text-gray-700 mb-2">{post.content}</div>
+            <div className="flex gap-2 mt-2">
+              <button className="px-3 py-1 bg-blue-100 text-blue-700 rounded hover:bg-blue-200 text-sm" onClick={() => handleShowComments(post.id)}>
+                Xem bình luận
+              </button>
+            </div>
+            {showComments === post.id && (
+              <div className="mt-2 bg-gray-50 p-2 rounded border">
+                <h4 className="font-semibold mb-1 text-sm">Bình luận</h4>
+                {commentsLoading ? (
+                  <div>Đang tải bình luận...</div>
+                ) : comments.length === 0 ? (
+                  <div className="text-gray-400 text-sm">Chưa có bình luận nào.</div>
+                ) : (
+                  <ul className="space-y-1 mb-2">
+                    {comments.map((c) => (
+                      <li key={c.id} className="text-sm border-b last:border-b-0 pb-1">
+                        <span className="font-medium">{c.author}:</span> {c.content}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                <div className="flex gap-2 mt-2">
+                  <input
+                    className="border p-1 flex-1"
+                    type="text"
+                    placeholder="Viết bình luận..."
+                    value={commentInput}
+                    onChange={e => setCommentInput(e.target.value)}
+                    onKeyDown={e => { if (e.key === "Enter") handleAddComment(post.id); }}
+                  />
+                  <button
+                    className="bg-blue-400 text-white px-2 rounded"
+                    onClick={() => handleAddComment(post.id)}
+                    disabled={addingComment}
+                  >
+                    {addingComment ? "Đang gửi..." : "Gửi"}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+        {posts.length === 0 && <div className="col-span-2 text-center text-gray-400">Chưa có bài viết nào đã duyệt.</div>}
+      </div>
+    </div>
+  );
+};
+
+export default MyAllPosts; 

--- a/src/pages/editor/MyPostDetail.jsx
+++ b/src/pages/editor/MyPostDetail.jsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+
+const API_URL = "http://localhost:3000/posts";
+const COMMENTS_URL = "http://localhost:3000/comments";
+const getCurrentUser = () => "editor";
+
+const MyPostDetail = () => {
+  const { id } = useParams();
+  const [post, setPost] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [comments, setComments] = useState([]);
+  const [commentsLoading, setCommentsLoading] = useState(true);
+  const [commentInput, setCommentInput] = useState("");
+  const [addingComment, setAddingComment] = useState(false);
+
+  useEffect(() => {
+    fetch(`${API_URL}/${id}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setPost(data);
+        setLoading(false);
+      });
+    fetch(`${COMMENTS_URL}?postId=${id}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setComments(data);
+        setCommentsLoading(false);
+      });
+  }, [id]);
+
+  const handleAddComment = async () => {
+    if (!commentInput.trim()) return;
+    setAddingComment(true);
+    await fetch(COMMENTS_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        postId: id,
+        author: getCurrentUser(),
+        content: commentInput,
+        createdAt: new Date().toISOString(),
+      }),
+    });
+    setCommentInput("");
+    // Reload comments
+    fetch(`${COMMENTS_URL}?postId=${id}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setComments(data);
+        setCommentsLoading(false);
+        setAddingComment(false);
+      });
+  };
+
+  if (loading) return <div>Đang tải...</div>;
+  if (!post) return <div>Không tìm thấy bài viết.</div>;
+
+  return (
+    <div className="max-w-2xl mx-auto py-8">
+      <h2 className="text-2xl font-bold mb-2">{post.title}</h2>
+      <div className="text-gray-500 mb-2">Ngày tạo: {post.createdAt || "-"}</div>
+      <div className="mb-6 text-gray-800 whitespace-pre-line">{post.content}</div>
+      <div className="bg-gray-50 p-4 rounded border">
+        <h4 className="font-semibold mb-2 text-lg">Bình luận</h4>
+        {commentsLoading ? (
+          <div>Đang tải bình luận...</div>
+        ) : comments.length === 0 ? (
+          <div className="text-gray-400 text-sm">Chưa có bình luận nào.</div>
+        ) : (
+          <ul className="space-y-2 mb-2">
+            {comments.map((c) => (
+              <li key={c.id} className="text-sm border-b last:border-b-0 pb-1">
+                <span className="font-medium">
+                  {c.author === getCurrentUser() ? `${c.author} (Bạn)` : c.author}
+                </span>: {c.content}
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="flex gap-2 mt-2">
+          <input
+            className="border p-1 flex-1"
+            type="text"
+            placeholder="Viết bình luận..."
+            value={commentInput}
+            onChange={e => setCommentInput(e.target.value)}
+            onKeyDown={e => { if (e.key === "Enter") handleAddComment(); }}
+          />
+          <button
+            className="bg-blue-500 text-white px-4 rounded"
+            onClick={handleAddComment}
+            disabled={addingComment}
+          >
+            {addingComment ? "Đang gửi..." : "Gửi"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MyPostDetail; 

--- a/src/pages/editor/MyPosts.jsx
+++ b/src/pages/editor/MyPosts.jsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const API_URL = "http://localhost:3000/posts";
+const getCurrentUser = () => "editor"; // Giả lập lấy user hiện tại
+
+const MyPosts = () => {
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  // Lấy bài viết từ db.json (API)
+  const fetchPosts = () => {
+    fetch(`${API_URL}?author=${getCurrentUser()}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setPosts(data);
+        setLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    fetchPosts();
+    // eslint-disable-next-line
+  }, []);
+
+  // Xóa bài viết (API)
+  const handleDelete = async (id) => {
+    await fetch(`${API_URL}/${id}`, { method: "DELETE" });
+    setPosts((prev) => prev.filter((p) => p.id !== id));
+  };
+
+  // Gửi duyệt bài viết nháp (API)
+  const handleSubmitForReview = async (post) => {
+    await fetch(`${API_URL}/${post.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...post, status: "pending" }),
+    });
+    setPosts((prev) => prev.map((p) => p.id === post.id ? { ...p, status: "pending" } : p));
+  };
+
+  if (loading) return <div>Đang tải...</div>;
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-2xl font-bold">Bài viết của tôi</h2>
+        <button
+          className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition"
+          onClick={() => navigate("/editor/create")}
+        >
+          + Tạo bài viết
+        </button>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {posts.map((post) => (
+          <div key={post.id} className="bg-white rounded shadow p-5 flex flex-col gap-2 border hover:shadow-lg transition">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-lg truncate">{post.title}</h3>
+              <span className={`px-2 py-1 rounded text-xs font-medium ml-2 ${post.status === "draft" ? "bg-gray-200 text-gray-700" : post.status === "published" ? "bg-green-100 text-green-700" : post.status === "pending" ? "bg-yellow-100 text-yellow-700" : "bg-gray-100 text-gray-500"}`}>{post.status === "draft" ? "Nháp" : post.status === "published" ? "Đã duyệt" : post.status === "pending" ? "Chờ duyệt" : post.status}</span>
+            </div>
+            <div className="text-sm text-gray-500">Ngày tạo: {post.createdAt || "-"}</div>
+            <div className="flex gap-2 mt-2">
+              <button className="px-3 py-1 bg-blue-100 text-blue-700 rounded hover:bg-blue-200 text-sm" onClick={() => navigate(`/editor/edit/${post.id}`)}>Sửa</button>
+              <button className="px-3 py-1 bg-red-100 text-red-700 rounded hover:bg-red-200 text-sm" onClick={() => handleDelete(post.id)}>Xóa</button>
+              {post.status === "draft" && (
+                <button className="px-3 py-1 bg-green-100 text-green-700 rounded hover:bg-green-200 text-sm" onClick={() => handleSubmitForReview(post)}>Gửi duyệt</button>
+              )}
+            </div>
+          </div>
+        ))}
+        {posts.length === 0 && <div className="col-span-2 text-center text-gray-400">Chưa có bài viết nào.</div>}
+      </div>
+    </div>
+  );
+};
+
+export default MyPosts; 

--- a/src/pages/editor/PostForm.jsx
+++ b/src/pages/editor/PostForm.jsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useState, useRef } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+const API_URL = "http://localhost:3000/posts";
+const getCurrentUser = () => "editor";
+
+const PostForm = () => {
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const textareaRef = useRef(null);
+
+  // Auto-resize textarea
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+      textareaRef.current.style.height = textareaRef.current.scrollHeight + "px";
+    }
+  }, [content]);
+
+  useEffect(() => {
+    if (id) {
+      setLoading(true);
+      fetch(`${API_URL}/${id}`)
+        .then((res) => res.json())
+        .then((data) => {
+          setTitle(data.title || "");
+          setContent(data.content || "");
+          setLoading(false);
+        });
+    } else {
+      setLoading(false);
+    }
+  }, [id]);
+
+  const savePost = async (status) => {
+    setSaving(true);
+    const post = {
+      title,
+      content,
+      status,
+      author: getCurrentUser(),
+      createdAt: new Date().toISOString().slice(0, 10),
+    };
+    try {
+      if (id) {
+        await fetch(`${API_URL}/${id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...post, id }),
+        });
+      } else {
+        const res = await fetch(`${API_URL}?author=${getCurrentUser()}&status=draft`);
+        const drafts = await res.json();
+        if (drafts.length > 0) {
+          await fetch(`${API_URL}/${drafts[0].id}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ ...drafts[0], ...post }),
+          });
+        } else {
+          await fetch(API_URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(post),
+          });
+        }
+      }
+      navigate("/editor/myposts");
+    } catch (e) {
+      alert("Lưu bài viết thất bại!");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return <div>Đang tải...</div>;
+
+  return (
+    <div className="w-full">
+      <form
+        className="w-full bg-white shadow-sm border rounded-none p-8 flex flex-col gap-6"
+        onSubmit={e => e.preventDefault()}
+      >
+        <div className="text-2xl font-bold mb-2">{id ? "Sửa bài viết" : "Tạo bài viết mới"}</div>
+        <input
+          className="border border-gray-300 rounded p-4 text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-blue-400 transition w-full"
+          type="text"
+          placeholder="Tiêu đề bài viết"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          maxLength={120}
+          required
+        />
+        <textarea
+          ref={textareaRef}
+          className="border border-gray-300 rounded p-4 text-base min-h-[160px] resize-none focus:outline-none focus:ring-2 focus:ring-blue-400 transition w-full"
+          placeholder="Nội dung bài viết..."
+          value={content}
+          onChange={e => setContent(e.target.value)}
+          required
+        />
+        <div className="flex flex-col sm:flex-row gap-3 justify-end mt-2">
+          <button
+            type="button"
+            className="bg-gray-300 hover:bg-gray-400 text-gray-800 px-6 py-2 rounded font-medium transition"
+            disabled={saving}
+            onClick={() => savePost("draft")}
+          >
+            Lưu nháp
+          </button>
+          <button
+            type="button"
+            className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-2 rounded font-medium transition"
+            disabled={saving}
+            onClick={() => savePost("pending")}
+          >
+            Gửi duyệt
+          </button>
+          <button
+            type="button"
+            className="bg-gray-200 hover:bg-gray-300 text-gray-700 px-6 py-2 rounded font-medium transition"
+            onClick={() => navigate("/editor/myposts")}
+          >
+            Hủy
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default PostForm; 

--- a/src/pages/manager/ManagerDashboard.jsx
+++ b/src/pages/manager/ManagerDashboard.jsx
@@ -1,10 +1,72 @@
-export default function ManagerDashboard() {
+import React, { useEffect, useState } from "react";
+
+const API_URL = "http://localhost:3000/posts";
+
+const ManagerDashboard = () => {
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  // Lấy danh sách bài viết chờ duyệt
+  const fetchPendingPosts = () => {
+    fetch(`${API_URL}?status=pending`)
+      .then((res) => res.json())
+      .then((data) => {
+        setPosts(data);
+        setLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    fetchPendingPosts();
+  }, []);
+
+  // Duyệt bài viết
+  const handleApprove = async (post) => {
+    await fetch(`${API_URL}/${post.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...post, status: "published" }),
+    });
+    setPosts((prev) => prev.filter((p) => p.id !== post.id));
+  };
+
+  // Từ chối bài viết
+  const handleReject = async (post) => {
+    await fetch(`${API_URL}/${post.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...post, status: "draft" }),
+    });
+    setPosts((prev) => prev.filter((p) => p.id !== post.id));
+  };
+
+  if (loading) return <div>Đang tải...</div>;
+
   return (
-    <div className="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
-      <h1 className="text-3xl font-bold text-blue-600 mb-6">
-        Manager Dashboard
-      </h1>
-      <p>Welcome, Manager! Manage operations here.</p>
+    <div className="max-w-3xl mx-auto py-8">
+      <h2 className="text-2xl font-bold mb-6">Quản lý bài viết chờ duyệt</h2>
+      <div className="space-y-4">
+        {posts.map((post) => (
+          <div key={post.id} className="bg-white rounded shadow p-4 flex flex-col gap-2 border">
+            <div className="flex justify-between items-center">
+              <div>
+                <h3 className="font-semibold text-lg">{post.title}</h3>
+                <div className="text-sm text-gray-500">Tác giả: {post.author || "-"}</div>
+                <div className="text-sm text-gray-500">Ngày tạo: {post.createdAt || "-"}</div>
+              </div>
+              <span className="px-2 py-1 rounded text-xs font-medium bg-yellow-100 text-yellow-700">Chờ duyệt</span>
+            </div>
+            <div className="text-gray-700 mb-2">{post.content}</div>
+            <div className="flex gap-2">
+              <button className="bg-green-500 text-white px-4 py-1 rounded" onClick={() => handleApprove(post)}>Duyệt</button>
+              <button className="bg-red-400 text-white px-4 py-1 rounded" onClick={() => handleReject(post)}>Từ chối</button>
+            </div>
+          </div>
+        ))}
+        {posts.length === 0 && <div className="text-center text-gray-400">Không có bài viết nào chờ duyệt.</div>}
+      </div>
     </div>
   );
-}
+};
+
+export default ManagerDashboard;

--- a/src/routes/EditorRouter.jsx
+++ b/src/routes/EditorRouter.jsx
@@ -1,0 +1,18 @@
+import { Route, Routes } from "react-router-dom";
+import EditorLayout from "../layouts/EditorLayout";
+import MyPosts from "../pages/editor/MyPosts";
+import PostForm from "../pages/editor/PostForm";
+import AllPosts from "../pages/editor/AllPosts";
+
+const EditorRouter = () => (
+  <Routes>
+    <Route path="/editor" element={<EditorLayout />}>
+      <Route path="myposts" element={<MyPosts />} />
+      <Route path="create" element={<PostForm />} />
+      <Route path="edit/:id" element={<PostForm />} />
+      <Route path="all" element={<AllPosts />} />
+    </Route>
+  </Routes>
+);
+
+export default EditorRouter; 

--- a/src/routes/privateRoutes.jsx
+++ b/src/routes/privateRoutes.jsx
@@ -1,7 +1,13 @@
 import PrivateLayout from "../layouts/PrivateLayout";
 import AdminDashboard from "../pages/admin/AdminDashboard";
-import EditorPosts from "../pages/editor/EditorPosts";
+import EditorLayout from "../layouts/EditorLayout";
+import MyPosts from "../pages/editor/MyPosts";
+import PostForm from "../pages/editor/PostForm";
+import AllPosts from "../pages/editor/AllPosts";
 import ManagerDashboard from "../pages/manager/ManagerDashboard";
+import MyAllPosts from "../pages/editor/MyAllPosts";
+import MyPostDetail from "../pages/editor/MyPostDetail";
+import AllPostDetail from "../pages/editor/AllPostDetail";
 
 export const privateRoutes = [
   {
@@ -13,9 +19,19 @@ export const privateRoutes = [
         allowedRoles: ["admin"],
       },
       {
-        path: "/editor/posts",
-        element: <EditorPosts />,
+        path: "/editor",
+        element: <EditorLayout />,
         allowedRoles: ["editor"],
+        children: [
+          { path: "myposts", element: <MyPosts />, allowedRoles: ["editor"] },
+          { path: "posts", element: <MyPosts />, allowedRoles: ["editor"] },
+          { path: "create", element: <PostForm />, allowedRoles: ["editor"] },
+          { path: "edit/:id", element: <PostForm />, allowedRoles: ["editor"] },
+          { path: "all", element: <AllPosts />, allowedRoles: ["editor"] },
+          { path: "myall", element: <MyAllPosts />, allowedRoles: ["editor"] },
+          { path: "myall/:id", element: <MyPostDetail />, allowedRoles: ["editor"] },
+          { path: "all/:id", element: <AllPostDetail />, allowedRoles: ["editor"] },
+        ],
       },
       {
         path: "/manager/dashboard",


### PR DESCRIPTION
- Giao diện Editor với sidebar , phân nhóm rõ ràng: Bài viết của tôi, Tất cả bài viết của tôi, Tất cả bài viết.
- Chức năng tạo bài viết với auto-save nháp, gửi duyệt, lưu vào db.json qua API.
- Quản lý bài viết: sửa, xóa, gửi duyệt, phân quyền rõ ràng giữa Editor và Manager.
- Trang Manager Dashboard ( cơ bản để test ) cho phép duyệt hoặc từ chối bài viết chờ duyệt.
- Trang chi tiết bài viết hiển thị nội dung, bình luận, cho phép bình luận mới, hiển thị rõ tác giả bình luận.
- Bình luận có thể xóa/sửa nếu là của mình, hiển thị thời gian gửi.
- Tất cả thao tác CRUD đều đồng bộ với db.json qua json-server.
